### PR TITLE
Executive positions change

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -69,7 +69,7 @@ A member's resignation shall be not considered effective unless it is made in wr
 
 ### 5.1 The Executive Committee shall:
 
-- 5.1.1 Consist of President, Vice-President, Secretary, Treasurer, Computer Systems Officer (CSO), Events Coordinator, Marketing Director.
+- 5.1.1 Consist of a President, a Vice-President, a Secretary, a Treasurer, at least one Events Coordinator, and a Marketing Director.
 
 - 5.1.2 Manage the affairs of the Society in accordance with this constitution and subject to the decisions of a General Meeting.
 
@@ -111,11 +111,9 @@ No member may be elected to any position on the Executive Committee who has not 
 
 - 5.5.4.4 ​Should the Treasurer be absent or ill, or neglect or refuse to do anything to be done by them under these rules, the Executive Committee may appoint any member of the Executive Committee to act in their stead.
 
-- 5.5.5 Computer Systems Officer. The Society Computer Systems Officer will co-ordinate administration of all of the computer related resources available for use by the Society.
+- 5.5.5 Events Coordinators. The Events Coordinators shall coordinate the timeline and planning of Society events.
 
-- 5.5.6 Events Coordinator. The Events Coordinator shall coordinate the timeline and planning of Society events.
-
-- 5.5.7 Marketing Director. The Marketing Director shall manage and moderate all Society social media platforms, and shall provide and distribute Society marketing material.
+- 5.5.6 Marketing Director. The Marketing Director shall manage and moderate all Society social media platforms, and shall provide and distribute Society marketing material.
 
 ### 5.6 Security
 


### PR DESCRIPTION
We are changing the executive positions to better fit the current status of the society.
- We no longer need a CSO position as we don't have physical servers to maintain or any outdated webservers to archive like in previous years. If we get a web server in the future, maintaining it will be a shared responsibility between the executives.
- We may have multiple events roles, as events roles are the primary drivers that allow us to maintain a physical presence within the university.
- The number of events positions is unspecified and up to the discretion of the executives and members at AGM.