### PR TITLE
Modified the expulsion rule

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -59,17 +59,21 @@ Membership shall be open to all Union members, and to all other persons satisfyi
 
 - 4.3.1 Any member whose actions either bring discredit on the Society, who has persistently refused to comply with the rules and regulations of the Society, or who has acted in a manner prejudicial to the interests of the Society may be considered for expulsion by the executive committee.
 
-- 4.3.2 The decision to expell a member must be conducted by a fully attended Executive Committee meeting with an affirmative vote of sixty-six percent or more.
+- 4.3.2 The decision to expel a member must be conducted by a fully attended Executive Committee meeting with an affirmative vote of sixty-six percent or more.
 
-- 4.3.3 A member who is being considered for expulsion shall have the right to to appear before the Executive Committee to show cause why they should not be expelled from the Society.
+- 4.3.3 A member who is being considered for expulsion shall have the right to appear before the Executive Committee to show cause why they should not be expelled from the Society.
 
-- 4.3.4 Should the subject member be a member also of the Executive Committee, their place on the Executive Committee shall be taken at the direction of the President or Vice-President, by a General Committee member, elected by the remaining members of the Executive Committee for the duration of that discussion of this rule.
+- 4.3.4 Should the subject member be a member also of the Executive Committee, their place on the Executive Committee shall be taken at the direction of the President or Vice-President, by a General Committee member, elected by the remaining members of the Executive Committee for the duration of that discussion of this rule. Persons expelled from the Society under this rule will be given the option of resigning.
 
-- 4.3.5 The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal shall be made in writing to the Secretary and must be lodged within fourteen (14) days of receiving written notification of the Committee’s decision. The lodging of an appeal will suspend the committee decision until the matter is considered by the Club Union.
+- 4.3.5 The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal shall be made in writing to the Secretary and must be lodged within fourteen (14) days of receiving written notification of the Committee’s decision. The lodging of an appeal will suspend the committee decision until the matter is considered by the Union.
 
-- 4.3.6 The Club Union has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
+- 4.3.6 The Union has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
 
-### 4.4 Resignation of Membership
+### 4.4 Disqualification
+
+- 4.4.1 A person being one month in arrears in annual subscription shall cease to be a member.
+
+### 4.5 Resignation of Membership
 
 A member's resignation shall be not considered effective unless it is made in writing to the Secretary nor until it is accepted by the Executive Committee. No refund of subscription or part thereof shall be made to a resigning member. No person having resigned shall be permitted to rejoin the Society except by payment of a fresh subscription.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -67,7 +67,7 @@ Membership shall be open to all Union members, and to all other persons satisfyi
 
 - 4.3.5 The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal shall be made in writing to the Secretary and must be lodged within fourteen (14) days of receiving written notification of the Committee’s decision. The lodging of an appeal will suspend the committee decision until the matter is considered by the Club Union.
 
-- 4.3.The Club Union has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
+- 4.3.6 The Club Union has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
 
 ### 4.4 Resignation of Membership
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -55,11 +55,19 @@ Membership shall be open to all Union members, and to all other persons satisfyi
 
 - 4.2.5 Annual subscription is dated for the calendar year, expiring on the 31st of December of that year.
 
-### 4.3 Disqualification
+### 4.3 Expulsion
 
-- 4.3.1 A person being one month in arrears in annual subscription shall cease to be a member.
+- 4.3.1 Any member whose actions either bring discredit on the Society, who has persistently refused to comply with the rules and regulations of the Society, or who has acted in a manner prejudicial to the interests of the Society may be considered for expulsion by the executive committee.
 
-- 4.3.2 Any member whose actions either bring discredit on the Society, who has persistently refused to comply with the rules and regulations of the Society, or who has acted in a manner prejudicial to the interests of the Society may, at the discretion of the Executive Committee after an affirmative vote of sixty-six percent or more of a fully attended Executive Committee meeting be asked to appear before the Executive Committee to show cause why they should not be expelled from the Society. Should the subject member not respond to the summons, the Executive Committee may decide the matter "in absentia". Should the subject member be a member also of the Executive Committee, their place on the Executive Committee shall be taken at the direction of the President or Vice-President, by another member of the Society, not already a member of the Executive Committee, elected by the remaining members of the Executive Committee for the duration of that discussion of this rule. The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal must be lodged with the President or the Secretary by the subject member within fourteen days of his notification of the Executive Committee's decision. The appeal will be considered at a Special General Meeting. Persons expelled from the Society under this rule will be given the option of resigning. No person who has been expelled from the Society under this rule (whether by expulsion or opted resignation) shall be re-admitted to membership except by consent of a majority of attending members at a General Meeting.
+- 4.3.2 The decision to expell a member must be conducted by a fully attended Executive Committee meeting with an affirmative vote of sixty-six percent or more.
+
+- 4.3.3 A member who is being considered for expulsion shall have the right to to appear before the Executive Committee to show cause why they should not be expelled from the Society.
+
+- 4.3.4 Should the subject member be a member also of the Executive Committee, their place on the Executive Committee shall be taken at the direction of the President or Vice-President, by a General Committee member, elected by the remaining members of the Executive Committee for the duration of that discussion of this rule.
+
+- 4.3.5 The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal shall be made in writing to the Secretary and must be lodged within fourteen (14) days of receiving written notification of the Committee’s decision. The lodging of an appeal will suspend the committee decision until the matter is considered by the Club Union.
+
+- 4.3.The Club Union has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
 
 ### 4.4 Resignation of Membership
 


### PR DESCRIPTION
The primary reason this change was considered was because Activate highly encourages removing the SGM clause from expulsions. Instead, they prefer us passing the matter over to them.

## Expulsion rule

The long rule has been broken up into sections. Most of it has been preserved, but the notable differences are:
- Instead of being explicitly asked to appear before the committee, a member being considered for expulsion has the right to contact the committee to show cause why they should not be expelled.
- When a member of an executive committee has been expelled, their place shall be taken by a general committee member rather than any club member.
- Any appeal shall be forwarded to the Club Union, rather than a Special General Meeting. This is because 200+ people shouldn't be notified because of a single member's misconduct. Activate hates the SGM rule and actively encouraged us to change it.
- The final resolution is decided by Activate.