### PR TITLE
amendment: 2024-A2 Update references to ActivateUTS, and current bank account operation.

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -13,6 +13,7 @@ Effective on and from the 16th March 1989
 - Amended 25th October 2018
 - Amended 29th October 2019
 - Amended 22nd October 2022
+- Amended 12th October 2024
 
 ## 1. NAME
 
@@ -26,13 +27,13 @@ The following terms, unless otherwise indicated to the contrary shall mean:
 
 - University, UTS: The University of Technology Sydney.
 
-- Union: ActivateUTS (formerly known as UTS Union).
+- ActivateUTS: The UTS clubs body (formerly known as UTS Union).
 
 ## 3. OBJECTS
 
 - 3.1. Encourage, foster, promote, develop, extend and govern interest and expertise in Computer Programming within the University.
 
-- 3.2. Remain affiliated with the Union.
+- 3.2. Remain affiliated with ActivateUTS.
 
 - 3.3. Subscribe to, become a member of, amalgamate and/or co-operate with any other organisation(s) whose objects are altogether or in part similar to those of the Society.
 
@@ -42,7 +43,7 @@ The following terms, unless otherwise indicated to the contrary shall mean:
 
 ### 4.1. Membership
 
-Membership shall be open to all Union members, and to all other persons satisfying the requirements of membership as may be determined by the Executive Committee from time to time.
+Membership shall be open to all UTS students, staff, and alumni; and to all other persons satisfying the requirements of membership as may be determined by the Executive Committee from time to time.
 
 ### 4.2. Conditions of Membership
 
@@ -66,9 +67,9 @@ Membership shall be open to all Union members, and to all other persons satisfyi
 
 - 4.3.4. Should the subject member be a member also of the Executive Committee, their place on the Executive Committee shall be taken at the direction of the President or Vice-President, by a General Committee member, elected by the remaining members of the Executive Committee for the duration of that discussion of this rule. Persons expelled from the Society under this rule will be given the option of resigning.
 
-- 4.3.5. The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal shall be made in writing to the Secretary and must be lodged within fourteen (14) days of receiving written notification of the Committee's decision. The lodging of an appeal will suspend the committee decision until the matter is considered by the Union.
+- 4.3.5. The Subject member shall have the right of appeal against the action of the Executive Committee. Such an appeal shall be made in writing to the Secretary and must be lodged within fourteen (14) days of receiving written notification of the Committee's decision. The lodging of an appeal will suspend the committee decision until the matter is considered by ActivateUTS.
 
-- 4.3.6. The Union has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
+- 4.3.6. ActivateUTS has the power to mediate and make the final resolution. The resolution is confirmed and effective from the date of confirmation.
 
 ### 4.4. Disqualification
 
@@ -148,11 +149,11 @@ The President, Vice-President, Secretary and Treasurer of the Society for the ti
 
 ### 6.3. Bank Account
 
-The Trustees shall open and maintain a bank account in the name of and on behalf of the Society.
+The Trustees shall maintain a bank account in the name of and on behalf of the Society.
 
 ### 6.4. Withdrawals and Account Signatories
 
-Monies shall not be drawn except by cheque or orders signed by two trustees or by the Secretary for the time being of the Union who may act as sole signatory on all accounts.
+Monies shall not be drawn except by cheque or orders signed by two trustees or by the ActivateUTS CEO for the time being who may act as sole signatory on all accounts.
 
 ## 7. MEETINGS
 
@@ -196,9 +197,9 @@ This constitution may be repealed, altered or amended only by the affirmative vo
 
 Notice of motions concerning any such amendments shall be lodged with the Secretary at least twenty-one (21) days prior to the date of such meeting and at least seven (7) days notice shall be given of such proposed amendments to every member.
 
-### 8.3. Lodging of Amendments with the Union
+### 8.3. Lodging of Amendments with ActivateUTS
 
-Details of any amendment that has been duly approved by the members shall be given to the Secretary of the Union within seven (7) days of such amendment being adopted.
+Details of any amendment that has been duly approved by the members shall be submitted as appropriate to ActivateUTS within seven (7) days of such amendment being adopted.
 
 ## 9. DISSOLUTION
 


### PR DESCRIPTION
# Rationale

- UTS Union is well and truly 'ActivateUTS' now
- Their constitution is officially titled now as the "ActivateUTS Constitution" <https://www.activateuts.com.au/wp-content/uploads/2022/02/ActivateUTS-Constitution-Adopted-by-Council-100517.pdf>