### PR TITLE
amendment: 2024-A4 Clubs Manager Co-signatory to prevent deadlock with Activate Policy (Primary Signatories)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -155,11 +155,7 @@ The Trustees shall open and maintain a bank account in the name of and on behalf
 
 - 6.4.1. Monies shall not be drawn except by cheque or orders signed by two trustees involving at least either the President or Treasurer.
 
-- 6.4.2. In the event both the President and Treasurer are absent or ill or otherwise unable to act as signatories, or neglect or refuse to operate the account in order to satisfy a debt, the Executive Committee may resolve by a vote:
-
-    - 6.4.2.1. To write to the ActivateUTS Clubs Manager explaining the circumstances of, and reasons for, a transaction;
-
-    - 6.4.2.2. And that one trustee and the ActivateUTS Clubs Manager for the time being are together authorised as signatories on such transaction.
+- 6.4.2. In the event both the President and Treasurer are absent or ill or otherwise unable to act as signatories on a transaction, or neglect or refuse to operate the account in order to satisfy an outstanding debt, the remaining Executive Committee may resolve to petition the ActivateUTS Clubs Manager for the time being to act as an authorised signatory, along with one trustee, to complete the transaction.
 
 - 6.4.3. In extraordinary circumstances, the ActivateUTS CEO for the time being may act as sole signatory on all accounts.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -157,7 +157,7 @@ The Trustees shall open and maintain a bank account in the name of and on behalf
 
 - 6.4.2. In the event both the President and Treasurer are absent or ill or otherwise unable to act as signatories on a transaction, or neglect or refuse to operate the account in order to satisfy an outstanding debt, the remaining Executive Committee may resolve to petition the ActivateUTS Clubs Manager for the time being to act as an authorised signatory, along with one trustee, to complete the transaction.
 
-- 6.4.3. In extraordinary circumstances, the ActivateUTS CEO for the time being may act as sole signatory on all accounts.
+- 6.4.3. The ActivateUTS CEO for the time being may act as sole signatory on all accounts.
 
 ## 7. MEETINGS
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -13,6 +13,7 @@ Effective on and from the 16th March 1989
 - Amended 25th October 2018
 - Amended 29th October 2019
 - Amended 22nd October 2022
+- Amended 12th October 2024
 
 ## 1. NAME
 
@@ -152,7 +153,7 @@ The Trustees shall open and maintain a bank account in the name of and on behalf
 
 ### 6.4. Withdrawals and Account Signatories
 
-Monies shall not be drawn except by cheque or orders signed by two trustees or by the Secretary for the time being of the Union who may act as sole signatory on all accounts.
+Monies shall not be drawn except by cheque or orders signed by two trustees, or by one trustee and the ActivateUTS Clubs Manager for the time being who will have been given a written explanation, or by the ActivateUTS CEO for the time being who may act as sole signatory on all accounts.
 
 ## 7. MEETINGS
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -155,11 +155,11 @@ The Trustees shall open and maintain a bank account in the name of and on behalf
 
 - 6.4.1. Monies shall not be drawn except by cheque or orders signed by two trustees involving at least either the President or Treasurer.
 
-- 6.4.2. In the event both the President and Treasurer are absent or ill, or neglect or refuse to operate the account in order to satisfy a debt, the Executive Committee may resolve by a vote:
+- 6.4.2. In the event both the President and Treasurer are absent or ill or otherwise unable to act as signatories, or neglect or refuse to operate the account in order to satisfy a debt, the Executive Committee may resolve by a vote:
 
-  - 6.4.2.1. To write to the ActivateUTS Clubs Manager explaining the circumstances of, and reasons for, a transaction;
+    - 6.4.2.1. To write to the ActivateUTS Clubs Manager explaining the circumstances of, and reasons for, a transaction;
 
-  - 6.4.2.2. And that one trustee and the ActivateUTS Clubs Manager for the time being are together authorised as signatories on such transaction.
+    - 6.4.2.2. And that one trustee and the ActivateUTS Clubs Manager for the time being are together authorised as signatories on such transaction.
 
 - 6.4.3. In extraordinary circumstances, the ActivateUTS CEO for the time being may act as sole signatory on all accounts.
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -153,7 +153,15 @@ The Trustees shall open and maintain a bank account in the name of and on behalf
 
 ### 6.4. Withdrawals and Account Signatories
 
-Monies shall not be drawn except by cheque or orders signed by two trustees, or by one trustee and the ActivateUTS Clubs Manager for the time being who will have been given a written explanation, or by the ActivateUTS CEO for the time being who may act as sole signatory on all accounts.
+- 6.4.1. Monies shall not be drawn except by cheque or orders signed by two trustees involving at least either the President or Treasurer.
+
+- 6.4.2. In the event both the President and Treasurer are absent or ill, or neglect or refuse to operate the account in order to satisfy a debt, the Executive Committee may resolve by a vote:
+
+  - 6.4.2.1. To write to the ActivateUTS Clubs Manager explaining the circumstances of, and reasons for, a transaction;
+
+  - 6.4.2.2. And that one trustee and the ActivateUTS Clubs Manager for the time being are together authorised as signatories on such transaction.
+
+- 6.4.3. In extraordinary circumstances, the ActivateUTS CEO for the time being may act as sole signatory on all accounts.
 
 ## 7. MEETINGS
 


### PR DESCRIPTION
# Rationale

- This is to bring practice in-line with current ActivateUTS policies and procedures.
- The constitution currently mentions Secretary (now CEO), but they will only act in extraordinary circumstances...
- According to ActivateUTS policy, there must be one "Primary Signatory" (Pres or *as elected*; not for the time being or acting) for every transaction;
  - Basically this ensures a UTS student is accountable, as President + Treasurer must be students at time of election according to Activate.
- If either Primary signatory are absent, we would need the Clubs Manager to co-sign to approve the transaction otherwise it would be blocked (and therefore unable to resolve any debts). Despite the constitution investing transaction ability in any two trustees.
- A vote by the Executive Committee to request the Clubs Manager's signature would resolve the 'crisis'