### PR TITLE
amendment: 2024-A7 Alumni Advisory Board

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -139,7 +139,7 @@ General Committee Officers are to be appointed at the discretion of the Executiv
 
 ### 5.8. Alumni Advisory Board
 
-Alumni Advisors are appointed upon the conclusion of their term on the Executive Committee or at the discretion of the Executive Committee. Alumni Advisors hold an indefinite term, to be reviewed annually at the commencement of an office period of the Executive Committee, until they choose to resign or are removed by the Executive Committee. Alumni Advisors do not hold a position on the Executive Committee, and shall serve a purely advisory role wherein, from time to time, they may provide considered guidance with no obligation on the Executive Committee. Persons considered for appointment must have held a role on the Executive Committee previously, or be recognised as a notable or otherwise distinguished member of the ProgSoc community.
+Alumni Advisors are appointed upon the conclusion of their term on the Executive Committee or at the discretion of the Executive Committee. Alumni Advisors hold an indefinite term, to be reviewed annually at the commencement of an office period of the Executive Committee, until they choose to resign or are removed by the Executive Committee. Alumni Advisors do not hold a position on the Executive Committee, and shall serve a purely advisory role wherein, from time to time, they may provide considered guidance with no obligation on the Executive Committee. Persons considered for appointment must have held a role on the Executive Committee previously, or be recognised as a notable or otherwise distinguished member of the Society.
 
 ## 6. FINANCE
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -13,6 +13,7 @@ Effective on and from the 16th March 1989
 - Amended 25th October 2018
 - Amended 29th October 2019
 - Amended 22nd October 2022
+- Amended 12th October 2024
 
 ## 1. NAME
 
@@ -135,6 +136,10 @@ All members holding access privileges to the Society room shall make all reasona
 ### 5.7. General Committee Officers
 
 General Committee Officers are to be appointed at the discretion of the Executive Committee and removed at the earlier of either removal by discretion of the Executive Committee, or at the end of an office period of the Executive Committee. General Committee Officers do not hold a position on the Executive Committee, and shall assist and advise the Executive Committee. Persons eligible for appointments must be financial members of the Society for the year they are appointed. General Committee Officer roles and positions are to be determined and revised by the Executive Committee from time to time.
+
+### 5.8. Alumni Advisory Board
+
+Alumni Advisors are appointed upon the conclusion of their term on the Executive Committee or at the discretion of the Executive Committee, and hold a perpetual term until they choose to resign or are removed by the Executive Committee. Alumni Advisors do not hold a position on the Executive Committee, and shall serve a purely advisory role wherein, from time to time, they may provide considered guidance with no obligation on the Executive Committee. Persons considered for appointment must have held a role on the Executive Committee previously, or be recognised as a notable or otherwise distinguished member of the community.
 
 ## 6. FINANCE
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -139,7 +139,7 @@ General Committee Officers are to be appointed at the discretion of the Executiv
 
 ### 5.8. Alumni Advisory Board
 
-Alumni Advisors are appointed upon the conclusion of their term on the Executive Committee or at the discretion of the Executive Committee, and hold a perpetual term until they choose to resign or are removed by the Executive Committee. Alumni Advisors do not hold a position on the Executive Committee, and shall serve a purely advisory role wherein, from time to time, they may provide considered guidance with no obligation on the Executive Committee. Persons considered for appointment must have held a role on the Executive Committee previously, or be recognised as a notable or otherwise distinguished member of the community.
+Alumni Advisors are appointed upon the conclusion of their term on the Executive Committee or at the discretion of the Executive Committee. Alumni Advisors hold an indefinite term, to be reviewed annually at the commencement of an office period of the Executive Committee, until they choose to resign or are removed by the Executive Committee. Alumni Advisors do not hold a position on the Executive Committee, and shall serve a purely advisory role wherein, from time to time, they may provide considered guidance with no obligation on the Executive Committee. Persons considered for appointment must have held a role on the Executive Committee previously, or be recognised as a notable or otherwise distinguished member of the ProgSoc community.
 
 ## 6. FINANCE
 


### PR DESCRIPTION
# Rationale:

- This proposal formalises existing practice, of the "Alumni" role on the Discord server and more generally the way the club recognises the value past ProgSoc'ers have to give in their past experiences.
- The UTS Cyber club has a similar, though annually elected, board fulfilling a similar purpose.
- 'Automatic' appointment deals with past Execs.
- 'Discretionary' appointments allow for those that have contributed to the growth and health of the club, but were never Execs in their time in the club.
- Perpetual/Indefinite terms most closely match how the existing "Alumni" role functions in the Discord.
- Consideration for the role as a past exec is the 'grandfather' clause.
- Consideration as a notable or distinguished member would make future Execs consider the broader impact such a person has had before appointment.
- Community refers to the places where ProgSoc gathers, though (addressing a comment) is likely best changed to "the Club"
- Arguments For lean toward making future Execs keep the "Alumni" role around should the Discord be retired in favour of another platform, and that some form of direct contact is kept with past ProgSoc'ers (and therefore the history of the club).