### PR TITLE
amendment: 2024-A3 AGM Season

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -13,6 +13,7 @@ Effective on and from the 16th March 1989
 - Amended 25th October 2018
 - Amended 29th October 2019
 - Amended 22nd October 2022
+- Amended 12th October 2024
 
 ## 1. NAME
 
@@ -162,7 +163,7 @@ In the absence of both the President and the Vice-President, the Committee membe
 
 ### 7.2. Annual General Meetings
 
-- 7.2.1. The Annual General Meeting shall be held in the month of October each year.
+- 7.2.1. The Annual General Meeting shall be held in either September or October of each year.
 
 - 7.2.2. The quorum at Annual General Meeting shall be fifty percent (50%) of members entitled to vote or fourteen (14) members entitled to vote whichever is lesser.
 


### PR DESCRIPTION
# Rationale

- Current ActivateUTS procedure sets AGM season as September and October.
- The deadline to submit AGM amendments, minutes, and complete the re-affiliation agreement is the first Tuesday in November.
- This would allow an earlier AGM should October be too busy, for whatever reason, and reduce the risk of disaffiliation.
- Activate's policy could mean an AGM on a Monday the 31st October, and re-affiliation due on a Tuesday 1st November.

(Addition: perhaps an extra amendment to specify at least 7 days before the first tuesday in november?)