### PR TITLE
amendment: 2024-A6 Set Quorum for AGM and SGM at 12

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -13,6 +13,7 @@ Effective on and from the 16th March 1989
 - Amended 25th October 2018
 - Amended 29th October 2019
 - Amended 22nd October 2022
+- Amended 12th October 2024
 
 ## 1. NAME
 
@@ -164,13 +165,13 @@ In the absence of both the President and the Vice-President, the Committee membe
 
 - 7.2.1. The Annual General Meeting shall be held in the month of October each year.
 
-- 7.2.2. The quorum at Annual General Meeting shall be fifty percent (50%) of members entitled to vote or fourteen (14) members entitled to vote whichever is lesser.
+- 7.2.2. The quorum at Annual General Meeting shall be fifty percent (50%) of members entitled to vote or twelve (12) members entitled to vote, whichever is lesser.
 
 ### 7.3. Ordinary General Meetings
 
 - 7.3.1. Ordinary General Meetings shall be held at such times, dates and places as may be decided at the Annual General Meeting.
 
-- 7.3.2. The quorum at an Ordinary General Meeting shall be thirty-three percent (33%) of members entitled to vote or fourteen (14) members entitled to vote, whichever is lesser.
+- 7.3.2. The quorum at an Ordinary General Meeting shall be thirty-three percent (33%) of members entitled to vote or twelve (12) members entitled to vote, whichever is lesser.
 
 ### 7.4. Special General Meetings
 


### PR DESCRIPTION
# Rationale

- Previous AGMs have come close to failing, with numbers only exceeding quorum after an effort to advertise more pointedly in the week beforehand.
- ActivateUTS's mandatory quorum is 6 (3 mandatory Execs), but 12 would be the democratic lowest for us with 6 (minimum) Exec roles to prevent Execs voting themselves in.