### PR TITLE
amendment: 2024-A8 Notice of Meetings

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -13,6 +13,7 @@ Effective on and from the 16th March 1989
 - Amended 25th October 2018
 - Amended 29th October 2019
 - Amended 22nd October 2022
+- Amended 12th October 2024
 
 ## 1. NAME
 
@@ -182,9 +183,9 @@ In the absence of both the President and the Vice-President, the Committee membe
 
 ### 7.5. Advertising Meetings
 
-- 7.5.1. Notice of the Annual and Ordinary General Meetings including time, place and business to be transacted shall be given to all financial members of the Society at least seven (7) days before the date of any such meeting.
+- 7.5.1. Notice of the Annual and Ordinary General Meetings including time and place shall be given to all financial members of the Society at least fourteen (14) days before the date of any such meeting, with notice of business to be transacted given at least seven (7) days ahead of the meeting.
 
-- 7.5.2. Notice of all Special General Meetings shall be given to all financial members of the Society at least seven (7) days before the date of such meeting.
+- 7.5.2. Notice of all Special General Meetings shall be given to all financial members of the Society at least fourteen (14) days before the date of such meeting.
 
 ## 8. AMENDMENT OF CONSTITUTION
 


### PR DESCRIPTION
# Rationale:

- Acting ourselves (ActivateUTS has not requested).
- This change is about bringing notice periods in-line with current ActivateUTS policy and de-facto practice, to prevent any confusion for future Execs.
- ActivateUTS mandates 14-days email notice before BOTH AGMs and SGMs; but only requires 7-days for the Agenda.
- ActivateUTS policy always beats club constitutions, but/so bringing in line the constitution will make things generally simpler.

## Extra

- ActivateUTS requires amendments to be approved before being motioned at AGMs.
- They can be slow to get back, so still having the extra time to re-issue business/agenda notice increases the chances of a successful AGM in circumstances where communication with Activate has been slow