### PR TITLE
amendment: 2026-A3 Duties of the Social Media Manager

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -119,6 +119,8 @@ No member may be elected to any position on the Executive Committee who has not 
 
 - 5.5.6. Marketing Director. The Marketing Director shall manage and moderate all Society social media platforms, and shall provide and distribute Society marketing material.
 
+- 5.5.7. Social Media Manager. The Social Media Manager shall manage and moderate all Society social media platforms, as well as disseminate all promotional material pertaining to the Society via social media platforms.
+
 ### 5.6. Security
 
 All members holding access privileges to physical and digital Society spaces (including, but not limited to: the room, website, mailing list, or chat server) shall make all reasonable efforts to maintain the security of such spaces.


### PR DESCRIPTION
# Rationale

* To ensure Marketing Directors do not need to split their attention between promotional material creation/management and social media account management, the Social Media Manager role is proposed to be made.
* This role is defined to be distinct from the Marketing Directors' duties, revamping the demarcation of roles in the Constitution before the 2026 amendments.