### PR TITLE
amendment: 2026-A4 Duties of Project Directors

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -119,6 +119,8 @@ No member may be elected to any position on the Executive Committee who has not 
 
 - 5.5.6. Marketing Director. The Marketing Director shall manage and moderate all Society social media platforms, and shall provide and distribute Society marketing material.
 
+- 5.5.8. Project Directors. The Project Directors shall manage, coordinate and moderate Society projects, guiding the overall direction of the projects to ensure they accomplish their intended purposes and benefit involved contributors and members of the Society overall. Every Society project corresponds directly to one or more code repositories owned by the Society's GitHub account.
+
 ### 5.6. Security
 
 All members holding access privileges to physical and digital Society spaces (including, but not limited to: the room, website, mailing list, or chat server) shall make all reasonable efforts to maintain the security of such spaces.


### PR DESCRIPTION
# Rationale

* Actively maintaining Society projects has been a goal of the Society for some time, as this promotes Society engagement while also benefitting the industry-readiness and graduate outcomes of the Society's members.
* This often requires oversight and guidance from dedicated personnel from within the Society to keep such initiatives viable, as well as other promotional initiatives to maximise contribution, engagement, and in turn the quality of such projects.